### PR TITLE
Correct estimate_chart ordering

### DIFF
--- a/Probabilities.py
+++ b/Probabilities.py
@@ -253,6 +253,6 @@ class ProbabilityCalculator:
         types_frame['Probability'] = types_frame['Count'].map(lambda count: count/n)
         types_frame.drop('Count', axis=1, inplace=True)
 
-        types_frame.reset_index(drop=True, inplace=True)
+        types_frame.sort_index(axis=0, inplace=True, ignore_index=True)
 
         return types_frame


### PR DESCRIPTION
ProbabilityCalculator.estimate_chart() is ordered by strength of hand rather than placing the high/low versions of the player's hand at the bottom.